### PR TITLE
fix: removed unused hotkey from publickey response

### DIFF
--- a/fiber/miner/core/models/encryption.py
+++ b/fiber/miner/core/models/encryption.py
@@ -25,4 +25,3 @@ class SymmetricKeyExchange(BaseModel):
 class PublicKeyResponse(BaseModel):
     public_key: str
     timestamp: float
-    hotkey: str

--- a/fiber/miner/endpoints/handshake.py
+++ b/fiber/miner/endpoints/handshake.py
@@ -18,7 +18,6 @@ async def get_public_key(config: Config = Depends(get_config)):
     return PublicKeyResponse(
         public_key=public_key,
         timestamp=time.time(),
-        hotkey=config.keypair.ss58_address,
     )
 
 


### PR DESCRIPTION
The publickey is not used in the `PublicKeyResponse` and should be removed. Otherwise miners with one single entrypoint somehow need to know from the validator which `miner_ss58` it expects to respond.
