### PR TITLE
refactor: remove redundant bittensor-commit-reveal dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "python-dotenv==1.0.1",
     "pydantic>2,<=2.9.2",
     "netaddr==1.3.0",
-    "bittensor-commit-reveal==0.1.0",
     "async-substrate-interface>=1.0.0,<2.0.0",
 ]
 


### PR DESCRIPTION
The bittensor-commit-reveal package is already included with bittensor 9.0.0, so we can remove it as a direct dependency.