### PR TITLE
Add dependencies to public encryption key route for enhanced security

### DIFF
--- a/fiber/encrypted/miner/endpoints/handshake.py
+++ b/fiber/encrypted/miner/endpoints/handshake.py
@@ -46,7 +46,6 @@ def factory_router() -> APIRouter:
         get_public_key, 
         methods=["GET"],
         dependencies=[
-            Depends(blacklist_low_stake),
             Depends(verify_request),
         ],
     )

--- a/fiber/encrypted/miner/endpoints/handshake.py
+++ b/fiber/encrypted/miner/endpoints/handshake.py
@@ -41,7 +41,15 @@ async def exchange_symmetric_key(
 
 def factory_router() -> APIRouter:
     router = APIRouter(tags=["Handshake"])
-    router.add_api_route("/public-encryption-key", get_public_key, methods=["GET"])
+    router.add_api_route(
+        "/public-encryption-key", 
+        get_public_key, 
+        methods=["GET"],
+        dependencies=[
+            Depends(blacklist_low_stake),
+            Depends(verify_request),
+        ],
+    )
     router.add_api_route(
         "/exchange-symmetric-key",
         exchange_symmetric_key,


### PR DESCRIPTION
With the request header we can add security and mitigation rule based on the request
unauthorized public access will not be allowed, only validator allow to access

Else public can raise ddos attack on a public path